### PR TITLE
optical image support

### DIFF
--- a/conf/config.json.template
+++ b/conf/config.json.template
@@ -14,6 +14,7 @@
   },
   "services": {
     "iso_images": "{{ sm_iso_images_url }}",
+    "optical_images": "{{ sm_optical_images_url }}",
     "mol_db": "{{ mol_db_url }}",
     "web_app_url": "{{ sm_webapp_url }}",
     "send_email": {{ sm_send_email | to_json }}

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -21,6 +21,16 @@ CREATE TABLE dataset (
 );
 CREATE INDEX ind_dataset_name ON dataset (name);
 
+DROP TABLE IF EXISTS optical_image;
+CREATE TABLE optical_image (
+  id      text PRIMARY KEY,
+  ds_id   text,
+  zoom    int,
+  CONSTRAINT opt_img_ds_id_fk FOREIGN KEY (ds_id)
+      REFERENCES dataset (id) MATCH SIMPLE
+      ON UPDATE NO ACTION ON DELETE CASCADE
+);
+
 DROP TABLE IF EXISTS job CASCADE;
 CREATE TABLE job (
 	id serial NOT NULL,

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(name='sm',
           "cpyImagingMSpec==0.2.4",
           "pyMSpec==0.1.2",
           "cpyMSpec==0.3.5",
-          "pyimzML==1.2.0"
+          "pyimzML==1.2.0",
+          "Pillow==4.2.1"
       ])

--- a/sm/engine/dataset_manager.py
+++ b/sm/engine/dataset_manager.py
@@ -217,21 +217,20 @@ class SMapiDatasetManager(DatasetManager):
     def _transform_scan(self, scan, transform_, dims, zoom):
         transform = np.array(transform_)
         assert transform.shape == (3, 3)
-        transform /= transform[2, 2]
+        transform = transform / transform[2, 2]
         transform[:, :2] /= zoom
         coeffs = transform.flat[:8]
         return scan.transform((dims[0] * zoom, dims[1] * zoom),
                               Image.PERSPECTIVE, coeffs, Image.BICUBIC)
 
-    def add_optical_image(self, ds, url, transform, **kwargs):
+    def add_optical_image(self, ds, optical_scan, transform, zoom_levels=[1, 2, 4, 8], **kwargs):
         """ Generate scaled and transformed versions of the provided optical image """
 
         dims = self._annotation_image_shape(ds.id)
-        optical_scan = Image.open(requests.get(url, stream=True).raw)
         img_store = self._optical_img_store()
 
         rows = []
-        for zoom in [1, 2, 4, 8]:
+        for zoom in zoom_levels:
             img = self._transform_scan(optical_scan, transform, dims, zoom)
             buf = io.BytesIO()
             img.save(buf, format='jpeg', quality=81)

--- a/sm/engine/png_generator.py
+++ b/sm/engine/png_generator.py
@@ -11,17 +11,19 @@ from sm.engine.util import SMConfig
 
 class ImageStoreServiceWrapper(object):
 
-    def __init__(self, iso_img_service_url):
-        self._iso_img_service_url = iso_img_service_url
+    def __init__(self, img_service_url, field_name='iso_image'):
+        self._img_service_url = img_service_url
+        self._field_name = field_name
         # empty URL is used for testing purposes
-        if self._iso_img_service_url:
+        if self._img_service_url:
             self._session = requests.Session()
-            self._session.mount(self._iso_img_service_url, HTTPAdapter(max_retries=5))
+            self._session.mount(self._img_service_url, HTTPAdapter(max_retries=5))
 
     def post_image(self, fp):
-        if not self._iso_img_service_url:
+        if not self._img_service_url:
             return 'XXX'
-        r = self._session.post(join(self._iso_img_service_url, 'upload'), files={'iso_image': fp})
+        r = self._session.post(join(self._img_service_url, 'upload'),
+                files={self._field_name: fp})
         r.raise_for_status()
         return r.json()['image_id']
 
@@ -29,8 +31,12 @@ class ImageStoreServiceWrapper(object):
         r = self._session.delete(url)
         r.raise_for_status()
 
+    def delete_image_by_id(self, id):
+        del_url = '{}/delete/{}'.format(self._img_service_url, id)
+        self.delete_image(del_url)
+
     def __str__(self):
-        return self._iso_img_service_url
+        return self._img_service_url
 
 
 class PngGenerator(object):

--- a/sm/rest/api.py
+++ b/sm/rest/api.py
@@ -1,9 +1,11 @@
 import json
 from datetime import datetime
 import logging
+import requests
 from bottle import post, run
 from bottle import request as req
 from bottle import response as resp
+from PIL import Image
 
 from sm.engine import DB, ESExporter
 from sm.engine import Dataset, SMapiDatasetManager, DatasetActionPriority
@@ -111,7 +113,8 @@ def delete_ds(ds_man, ds, params):
 @post('/v1/datasets/<ds_id>/add-optical-image')
 @sm_modify_dataset('ADD_OPTICAL_IMAGE')
 def add_optical_image(ds_man, ds, params):
-    ds_man.add_optical_image(ds, params['url'], params['transform'])
+    image = Image.open(requests.get(params['url'], stream=True).raw)
+    ds_man.add_optical_image(ds, image, params['transform'])
 
 if __name__ == '__main__':
     init_logger()

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -222,8 +222,7 @@ class TestSMDaemonDatasetManager:
 
             ds_man.delete(ds)
 
-            urls = ['{}/delete/{}'.format(sm_config['services']['iso_images'], 'iso_image_{}_id'.format(id))
-                    for id in range(1, 3)]
-            img_store_service_mock.delete_image.assert_has_calls([call(urls[0]), call(urls[1])])
+            ids = ['iso_image_{}_id'.format(id) for id in range(1, 3)]
+            img_store_service_mock.delete_image_by_id.assert_has_calls([call(ids[0]), call(ids[1])])
             es_mock.delete_ds.assert_called_with(ds_id)
             assert db.select_one('SELECT * FROM dataset WHERE id = %s', ds_id) == []


### PR DESCRIPTION
* /add_optical_image REST API
* create 4 transformed optical images with 1x, 2x, 4x, 8x zoom
* sends the created images to the optical image storage
* stores the image IDs in a new database table called optical_image