### PR TITLE
Add environment.yml file to sm-engine

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+name: sm
+dependencies:
+  - python=3.6
+  - numpy=1.11.2
+  - scipy=0.18.1
+  - matplotlib=2
+  - pandas=0.22.0
+  - cffi
+  - libgcc
+  - psycopg2=2.7.1
+  - pip:
+    - requests
+    - pytest
+    - recommonmark
+    - boto3
+    - fabric3
+    - pypng
+    - pyyaml
+    - elasticsearch
+    - elasticsearch_dsl
+    - pika>=0.11.0b1
+    - bottle
+    - pyspark
+    - pysparkling
+    - PyArrow>=0.8.0
+


### PR DESCRIPTION
Having this file in the repository makes it a lot easier to set up the conda environment.
Compared to the copy in `sm-engine-ansible` I have added `pyspark`

One issue I wasn't able to find an elegant solution for is this project's dependence on also being installed into the environment. The only clean way I found to do that was with the command `pip install -e .`