### PR TITLE
Private Prototype

### DIFF
--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE dataset (
 	status				text,
 	optical_image text,
 	transform			float[],
+	is_public     boolean not null default(true),
 	CONSTRAINT dataset_id_pk PRIMARY KEY(id)
 );
 CREATE INDEX ind_dataset_name ON dataset (name);

--- a/scripts/update_es_index.py
+++ b/scripts/update_es_index.py
@@ -17,15 +17,19 @@ def _reindex_all(conf):
     new_index = es_man.another_index_name(es_man.internal_index_name(alias))
     es_man.create_index(new_index)
 
-    tmp_es_config = deepcopy(es_config)
-    tmp_es_config['index'] = new_index
+    try:
+        tmp_es_config = deepcopy(es_config)
+        tmp_es_config['index'] = new_index
 
-    db = DB(conf['db'])
-    es_exp = ESExporter(db, tmp_es_config)
-    rows = db.select('select id, name, config from dataset')
-    _reindex_datasets(rows, es_exp)
+        db = DB(conf['db'])
+        es_exp = ESExporter(db, tmp_es_config)
+        rows = db.select('select id, name, config from dataset')
+        _reindex_datasets(rows, es_exp)
 
-    es_man.remap_alias(tmp_es_config['index'], alias=alias)
+        es_man.remap_alias(tmp_es_config['index'], alias=alias)
+    except Exception as e:
+        es_man.delete_index(new_index)
+        raise e
 
 
 def _reindex_datasets(rows, es_exp):

--- a/sm/engine/es_export.py
+++ b/sm/engine/es_export.py
@@ -51,13 +51,15 @@ DATASET_SEL = '''SELECT
     input_path,
     upload_dt,
     dataset.status,
-    to_char(max(finish), 'YYYY-MM-DD HH24:MI:SS')
+    to_char(max(finish), 'YYYY-MM-DD HH24:MI:SS'),
+    is_public
 FROM dataset LEFT JOIN job ON job.ds_id = dataset.id
 WHERE dataset.id = %s
 GROUP BY dataset.id'''
 
 DATASET_COLUMNS = ('ds_id', 'ds_name', 'ds_config', 'ds_meta', 'ds_input_path',
-                   'ds_upload_dt', 'ds_status', 'ds_last_finished')
+                   'ds_upload_dt', 'ds_status', 'ds_last_finished', 'ds_is_public')
+
 
 def init_es_conn(es_config):
     hosts = [{"host": es_config['host'], "port": int(es_config['port'])}]
@@ -184,6 +186,7 @@ class ESExporter(object):
         submitter = dataset.get('ds_meta', {}).get('Submitted_By', {}).get('Submitter', None)
         if submitter:
             dataset['ds_submitter'] = submitter.get('First_Name', '') + ' ' + submitter.get('Surname', '')
+            dataset['ds_submitter_email'] = submitter.get('Email', '')
 
     def _ds_get_by_id(self, ds_id):
         dataset = dict(zip(DATASET_COLUMNS, self._db.select(DATASET_SEL, ds_id)[0]))

--- a/sm/rest/api.py
+++ b/sm/rest/api.py
@@ -70,7 +70,9 @@ def add_ds():
                      params.get('input_path'),
                      params.get('upload_dt', now),
                      params.get('metadata', None),
-                     params.get('config'))
+                     params.get('config'),
+                     is_public=params.get('is_public')
+                     )
         db = _create_db_conn()
         ds_man = _create_dataset_manager(db)
         ds_man.add(ds, del_first=params.get('del_first', False),
@@ -127,6 +129,7 @@ def update_ds(ds_man, ds, params):
     ds.input_path = params.get('input_path', ds.input_path)
     ds.meta = params.get('metadata', ds.meta)
     ds.config = params.get('config', ds.config)
+    ds.is_public = params.get('is_public', ds.is_public)
 
     ds_man.update(ds, priority=params.get('priority', DatasetActionPriority.DEFAULT))
 


### PR DESCRIPTION
* Adds `dataset.is_public` column and populates it from metadata
* Fixes an issue in `update_es_index.py` - if there is an error during the update, it will exit with both `sm-yin` and `sm-yang` still existing. This causes subsequent runs immediately fail because there is an assertion that only one index should exist at a time. The fix is to delete the broken index if there's an error

Caution:
* This includes a database schema change that will have to be manually applied until we get a migrations system: `ALTER TABLE dataset ADD COLUMN is_public boolean not null default(true);`
* Because `is_public` is non-nullable, this needs the `feature/private-prototype` branches in sm-graphql and sm-webapp to be merged at the same time.