### PR TITLE
Stop using 'metaspace_options'

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
     - elasticsearch_dsl
     - pika>=0.11.0b1
     - bottle
-    - pyspark
+    - pyspark==2.3.0
     - pysparkling
     - PyArrow>=0.8.0
 

--- a/scripts/create_schema.sql
+++ b/scripts/create_schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE dataset (
 	optical_image text,
 	transform			float[],
 	is_public     boolean not null default(true),
+	mol_dbs			  text[],
 	CONSTRAINT dataset_id_pk PRIMARY KEY(id)
 );
 CREATE INDEX ind_dataset_name ON dataset (name);

--- a/scripts/update_es_index.py
+++ b/scripts/update_es_index.py
@@ -37,13 +37,13 @@ def _reindex_datasets(rows, es_exp):
     for ds_id, ds_name, ds_config in rows:
         try:
             es_exp.delete_ds(ds_id)
-            for mol_db_dict in ds_config['databases']:
-                mol_db = MolecularDB(name=mol_db_dict['name'], iso_gen_config=ds_config['isotope_generation'])
+            for mol_db_name in ds_config['databases']:
+                mol_db = MolecularDB(name=mol_db_name, iso_gen_config=ds_config['isotope_generation'])
                 isocalc = IsocalcWrapper(ds_config['isotope_generation'])
                 es_exp.index_ds(ds_id, mol_db=mol_db, isocalc=isocalc)
         except Exception as e:
             new_msg = 'Failed to reindex(ds_id={}, ds_name={}): {}'.format(ds_id, ds_name, e)
-            logger.error(new_msg)
+            logger.error(new_msg, exc_info=True)
 
 
 def reindex_results(ds_id, ds_mask):

--- a/sm/engine/dataset_manager.py
+++ b/sm/engine/dataset_manager.py
@@ -126,9 +126,8 @@ class SMDaemonDatasetManager(DatasetManager):
 
         self._es.delete_ds(ds.id)
 
-        moldb_names = [d['name'] for d in ds.config['databases']]
         for job_id, mol_db_name in self._finished_job_moldbs(ds.id):
-            if mol_db_name not in moldb_names:
+            if mol_db_name not in ds.config['databases']:
                 self._db.alter("DELETE FROM job WHERE id = %s", job_id)
             else:
                 mol_db = MolecularDB(name=mol_db_name,

--- a/sm/engine/db.py
+++ b/sm/engine/db.py
@@ -5,7 +5,6 @@
 .. moduleauthor:: Vitaly Kovalev <intscorpio@gmail.com>
 """
 from functools import wraps
-from traceback import format_exc
 
 import psycopg2
 import psycopg2.extensions
@@ -27,8 +26,7 @@ def db_decor(func):
             logger.debug(args[0])
             res = func(self, *args, **kwargs)
         except Exception as e:
-            # logger.error(format_exc())
-            logger.error('%s, SQL: %s\n%s', e, args[0], str(args[1:])[:1000])
+            logger.error('SQL: %s,\nArgs: %s', args[0], str(args[1:])[:1000], exc_info=True)
             self.conn.rollback()
             raise
         else:

--- a/sm/engine/es_export.py
+++ b/sm/engine/es_export.py
@@ -27,19 +27,12 @@ ANNOTATIONS_SEL = '''SELECT
     COALESCE(m.msm, 0::real) AS msm,
     m.adduct,
     j.id AS job_id,
---    f.id AS sf_id,
     m.fdr as pass_fdr,
---    tp.centr_mzs AS centroid_mzs,
     m.iso_image_ids as iso_image_ids,
     ds.config->'isotope_generation'->'charge'->'polarity' as polarity
 FROM iso_image_metrics m
---JOIN sum_formula f ON f.id = m.sf_id
 JOIN job j ON j.id = m.job_id
 JOIN dataset ds ON ds.id = j.ds_id
--- JOIN theor_peaks tp ON tp.sf = f.sf AND tp.adduct = m.adduct
--- 	AND tp.sigma::real = (ds.config->'isotope_generation'->>'isocalc_sigma')::real
--- 	AND tp.charge = (CASE WHEN ds.config->'isotope_generation'->'charge'->>'polarity' = '+' THEN 1 ELSE -1 END)
--- 	AND tp.pts_per_mz = (ds.config->'isotope_generation'->>'isocalc_pts_per_mz')::int
 WHERE ds.id = %s AND m.db_id = %s
 ORDER BY COALESCE(m.msm, 0::real) DESC'''
 
@@ -52,13 +45,14 @@ DATASET_SEL = '''SELECT
     upload_dt,
     dataset.status,
     to_char(max(finish), 'YYYY-MM-DD HH24:MI:SS'),
-    is_public
+    is_public,
+    mol_dbs
 FROM dataset LEFT JOIN job ON job.ds_id = dataset.id
 WHERE dataset.id = %s
 GROUP BY dataset.id'''
 
 DATASET_COLUMNS = ('ds_id', 'ds_name', 'ds_config', 'ds_meta', 'ds_input_path',
-                   'ds_upload_dt', 'ds_status', 'ds_last_finished', 'ds_is_public')
+                   'ds_upload_dt', 'ds_status', 'ds_last_finished', 'ds_is_public', "ds_mol_dbs")
 
 
 def init_es_conn(es_config):

--- a/sm/engine/search_job.py
+++ b/sm/engine/search_job.py
@@ -142,8 +142,8 @@ class SearchJob(object):
         moldb_service = MolDBServiceWrapper(self._sm_config['services']['mol_db'])
         completed_moldb_ids = {moldb_service.find_db_by_id(db_id)['id']
                                for (_, db_id) in self._db.select(JOB_ID_MOLDB_ID_SEL, self._ds.id)}
-        new_moldb_ids = {moldb_service.find_db_by_name_version(d['name'], d.get('version', None))[0]['id']
-                         for d in self._ds.config['databases']}
+        new_moldb_ids = {moldb_service.find_db_by_name_version(moldb_name)[0]['id']
+                         for moldb_name in self._ds.config['databases']}
         return completed_moldb_ids, new_moldb_ids
 
     def run(self, ds):

--- a/sm/engine/sm_daemon.py
+++ b/sm/engine/sm_daemon.py
@@ -68,6 +68,7 @@ class SMDaemon(object):
             logger.warning('SEM failed to send email to {}'.format(email))
 
     def _is_possible_send_email(self, ds_meta):
+        # TODO: take 'notify_submitter' from message not metadata
         submitter = ds_meta.get('Submitted_By', {}).get('Submitter', None)
         return (self._sm_config['services']['send_email']
                 and submitter

--- a/sm/rest/api.py
+++ b/sm/rest/api.py
@@ -71,18 +71,19 @@ def add_ds():
                      params.get('upload_dt', now),
                      params.get('metadata', None),
                      params.get('config'),
-                     is_public=params.get('is_public')
-                     )
+                     is_public=params.get('is_public'),
+                     mol_dbs=params.get('mol_dbs'))
         db = _create_db_conn()
         ds_man = _create_dataset_manager(db)
-        ds_man.add(ds, del_first=params.get('del_first', False),
-                   priority=params.get('priority', DatasetActionPriority.DEFAULT))
+        priority = params.get('priority', DatasetActionPriority.DEFAULT)
+        ds_man.add(ds, del_first=params.get('del_first', False), priority=priority)
         db.close()
         return {
             'status': OK['status'],
             'ds_id': ds_id
         }
-    except Exception:
+    except Exception as e:
+        logger.error(e, exc_info=True)
         resp.status = ERROR['status_code']
         return {
             'status': ERROR['status'],
@@ -112,7 +113,8 @@ def sm_modify_dataset(request_name):
                     'status': ERR_OBJECT_NOT_EXISTS['status'],
                     'ds_id': ds_id
                 }
-            except Exception:
+            except Exception as e:
+                logger.error(e, exc_info=True)
                 resp.status = ERROR['status_code']
                 return {
                     'status': ERROR['status'],
@@ -127,7 +129,7 @@ def sm_modify_dataset(request_name):
 def update_ds(ds_man, ds, params):
     ds.name = params.get('name', ds.name)
     ds.input_path = params.get('input_path', ds.input_path)
-    ds.meta = params.get('metadata', ds.meta)
+    ds.metadata = params.get('metadata', ds.metadata)
     ds.config = params.get('config', ds.config)
     ds.is_public = params.get('is_public', ds.is_public)
 

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -89,7 +89,7 @@ class TestSMapiDatasetManager:
 
         ds_id = '2000-01-01'
         ds = create_ds(ds_id=ds_id, ds_config=ds_config)
-        ds.meta = {'new': 'metadata'}
+        ds.metadata = {'new': 'metadata'}
 
         ds_man.update(ds)
 

--- a/tests/test_sm_daemon.py
+++ b/tests/test_sm_daemon.py
@@ -150,7 +150,7 @@ class TestSMDaemonSingleEventCases:
     def test_update(self, fill_db, clean_ds_man_mock, delete_queue, ds_config, sm_config):
         api_ds_man = create_api_ds_man(sm_config=sm_config)
         ds = create_ds(ds_config=ds_config)
-        ds.meta['new'] = 'field'
+        ds.metadata['new'] = 'field'
 
         api_ds_man.update(ds)
 
@@ -218,7 +218,7 @@ class TestSMDaemonTwoEventsCases:
         api_ds_man = create_api_ds_man(sm_config=sm_config)
         ds = create_ds(ds_config=ds_config)
         api_ds_man.add(ds, priority=DatasetActionPriority.DEFAULT)
-        ds.meta['new_field'] = 'value'
+        ds.metadata['new_field'] = 'value'
         api_ds_man.update(ds, priority=DatasetActionPriority.DEFAULT)
 
         run_sm_daemon()


### PR DESCRIPTION
The code was refactored in order to stop relying on the 'metaspace_options' section of the metadata.