### PR TITLE
Env/config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 .idea
 .vscode
+.pytest_cache
 *.pkl
 *.zip
 conf/*.json

--- a/conf/config.json.template
+++ b/conf/config.json.template
@@ -2,7 +2,7 @@
   "bottle": {
     "host": "localhost",
     "port": 5123,
-    "refresh": false,
+    "reloader": false,
     "debug": false
   },
   "defaults": {

--- a/conf/config.json.template
+++ b/conf/config.json.template
@@ -1,4 +1,10 @@
 {
+  "bottle": {
+    "host": "localhost",
+    "port": 5123,
+    "refresh": false,
+    "debug": false
+  },
   "defaults": {
     "adducts": {{ sm_default_adducts | to_json }}
   },

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,9 @@ dependencies:
     - pyspark==2.3.0
     - pysparkling
     - PyArrow>=0.8.0
-
+    - pyImagingMSpec==0.1.4
+    - cpyImagingMSpec==0.2.4
+    - pyMSpec==0.1.2
+    - cpyMSpec==0.3.5
+    - pyimzML==1.2.1
+    - Pillow==4.2.1

--- a/sm/rest/api.py
+++ b/sm/rest/api.py
@@ -163,4 +163,4 @@ if __name__ == '__main__':
 
     init_loggers(SMConfig.get_conf()['logs'])
     logger = logging.getLogger(name='api')
-    run(host='localhost', port=5123)
+    run(**SMConfig.get_conf()['bottle'])


### PR DESCRIPTION
* Makes sm-api get the parameters for Bottle from config. This is useful in 2 places:
    * `reloader=True` can be used so that Bottle automatically reloads on file changes, without that setting also affecting production
    * `host` can be changed to `0.0.0.0` to make the API externally accessible (needed for Docker)
* Adds missing dependencies to environment.yml. These dependencies were listed in `setup.py`. This may not be correct - I'm not sure whether the dependency lists in `setup.py` and `environment.yml` are meant to be used differently.
* Adds `.pytest_cache` to `.gitignore`